### PR TITLE
chore: 修改homepage的连接，将http变为https连接

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bugs": {
         "url": "https://github.com/baukh789/GridManager/issues"
     },
-    "homepage": "http://gridmanager.lovejavascript.com",
+    "homepage": "https://gridmanager.lovejavascript.com",
     "keywords": [
         "gridmanager",
         "table",


### PR DESCRIPTION
## 修改package.json里面的homepage的连接，将http变为https连接（npmjs官网点击homepage链接无法跳转,如下图）

![image](https://github.com/baukh789/GridManager/assets/85545304/dc7c116a-8e4d-4ea4-b894-7ff3df6e8810)

![1688195213355](https://github.com/baukh789/GridManager/assets/85545304/97fe9d78-396a-47f6-8bb7-1dc1dfc6616b)
